### PR TITLE
DL is obsolete on ruby 2.2.

### DIFF
--- a/lib/locale/driver/win32.rb
+++ b/lib/locale/driver/win32.rb
@@ -22,7 +22,7 @@
 require "locale/driver/env"
 require "locale/driver/win32_table"
 
-require "dl/import"
+require "fiddle/import"
 
 module Locale
   # Locale::Driver::Win32 module for win32.
@@ -31,7 +31,7 @@ module Locale
   module Driver
     module Win32
       module Kernel32
-        extend DL::Importer
+        extend Fiddle::Importer
         dlload "kernel32.dll"
         extern "int GetThreadLocale()"
       end

--- a/test/test_driver_win32.rb
+++ b/test/test_driver_win32.rb
@@ -60,6 +60,6 @@ begin
       assert_equal "CP1252", Locale::Driver::Win32.charset
     end
   end
-rescue LoadError, DL::DLError, NameError
+rescue LoadError, Fiddle::DLError, NameError
   puts "win32 test was skipped."
 end


### PR DESCRIPTION
Hello.This library is very useful!

I would like to support Ruby 2.2 for Windows

"DL" module is obsolete on ruby 2.2.
"DL" replace "Fiddle".

Please check my patch.