### PR TITLE
Fix warning: assigned but unused variable - spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,6 @@ end
 
 helper = Bundler::GemHelper.new(base_dir)
 helper.install
-spec = helper.gemspec
 
 desc "Run tests"
 task :test do


### PR DESCRIPTION
Fix a warning when running `rake test`

The variable `spec` is not used from this commit
https://github.com/ruby-gettext/locale/commit/b3705021b602782991479b943e52d3d07596c4db