### PR TITLE
2.0.10 for missing Ruby 2.2.x compatibility

### DIFF
--- a/lib/locale/driver/win32.rb
+++ b/lib/locale/driver/win32.rb
@@ -22,7 +22,20 @@
 require "locale/driver/env"
 require "locale/driver/win32_table"
 
-require "dl/import"
+if RUBY_VERSION < "2.1"
+  require "dl/import"
+else
+  require 'fiddle/import'
+  
+  # For now map DL to Fiddler versus updating all the code below
+  # net-ssh did it first
+  module DL
+    CPtr ||= Fiddle::Pointer
+    if RUBY_PLATFORM != "java"
+      RUBY_FREE ||= Fiddle::RUBY_FREE
+    end
+  end
+end
 
 module Locale
   # Locale::Driver::Win32 module for win32.

--- a/lib/locale/version.rb
+++ b/lib/locale/version.rb
@@ -7,6 +7,6 @@
   license terms as Ruby.
 =end
 module Locale
-  VERSION = "2.0.9"
+  VERSION = "2.0.10"
 end
 

--- a/locale.gemspec
+++ b/locale.gemspec
@@ -44,6 +44,8 @@ Ruby-Locale is the pure ruby library which provides basic APIs for localization.
     s.test_files = Dir.glob("test/test_*.rb")
   end
 
+  s.required_ruby_version = "< 2.3.0"
+  
   s.add_development_dependency("rake")
   s.add_development_dependency("bundler")
   s.add_development_dependency("yard")


### PR DESCRIPTION
Why Ruby 2.2.x ? because that's the last version Rails 3.2.x supports.

This is a long upgrade path.