### PR TITLE
Test Ruby 3.0 and 3.1 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0"
+          - "3.1"
           - truffleruby-head
         runs-on:
           - ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
Both Ruby version should be compatible so we can test them on CI.