### PR TITLE
Make Fiddle only install on Windows

### DIFF
--- a/locale.gemspec
+++ b/locale.gemspec
@@ -45,7 +45,9 @@ Ruby-Locale is the pure ruby library which provides basic APIs for localization.
   end
 
   # This is needed only for Windows.
-  s.add_dependency("fiddle")
+  if RUBY_PLATFORM =~ /mingw|mswin|x64_mingw/
+    s.add_dependency("fiddle")
+  end
 
   s.add_development_dependency("bundler")
   s.add_development_dependency("kramdown")


### PR DESCRIPTION
We are seeing some failures in our ci after bundler started to use the new version of locale with:

```bash
[2026-03-02T02:10:40.222Z]         In Gemfile:
[2026-03-02T02:10:40.222Z]           voxpupuli-test was resolved to 9.2.1, which depends on
[2026-03-02T02:10:40.222Z]             rspec-puppet-utils was resolved to 3.4.0, which depends on
[2026-03-02T02:10:40.222Z]               puppetlabs_spec_helper was resolved to 8.0.0, which depends on
[2026-03-02T02:10:40.222Z]                 puppet-syntax was resolved to 4.1.1, which depends on
[2026-03-02T02:10:40.222Z]                   puppet was resolved to 8.10.0, which depends on
[2026-03-02T02:10:40.222Z]                     locale was resolved to 2.1.5, which depends on
[2026-03-02T02:10:40.222Z]                       fiddle
```

Did a little dig and found https://github.com/ruby-gettext/locale/blob/849c0d76b214892651d6015173574e005d1cde08/locale.gemspec#L47 if it's really only required on Windows, we should be adding the check there so it does not fail on Linux system when `libffi-devel` is not present.